### PR TITLE
インストール先 URL を Chrome Web Store 版に差し替える

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
     <meta property="og:url" content="https://kadaiowatter.sakanana.me">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:creator" content="@naname_eis">
-    <title>kadaiowatter</title>    
+    <title>kadaiowatter</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
     <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;700&display=swap" rel="stylesheet">
@@ -78,7 +78,7 @@
                         <p class="lead">提出完了画面にシェアボタンを追加。ボタンをクリックするだけで、課題が終わったことを簡単にツイートできます。</p>
                         <p class="lead">生成されるツイートには、ハッシュタグと科目名に加え、「課題おわった」の画像を表示するURLが含まれます。</p>
                     </div>
-                </div>                
+                </div>
                 <div class="col d-flex align-items-start">
                     <div class="icon-square d-inline-flex align-items-center justify-content-center fs-4 flex-shrink-0 me-3">
                         <i class="bi bi-check-square-fill"></i>
@@ -97,9 +97,8 @@
                 <div class="row flex-lg-row-reverse align-items-center justify-content-center g-5 py-5">
                     <div class="col-10 col-sm-8 col-lg-6">
                         <h1 class="fw-bold lh-1 mb-3">インストール方法</h1>
-                        <p class="lead"><a href="https://github.com/saka-naname/kadaiowatter/releases" class="link-light">Releases</a>からzip形式の拡張機能本体をダウンロードし、デベロッパーモードで導入してください。</p>
-                        <p class="lead">今後、Chrome Web Storeへの公開も検討しています。</p>
-                        <a href="https://github.com/saka-naname/kadaiowatter#導入方法" class="btn btn-light"><i class="bi bi-chevron-right"></i> 詳しく見る </a>
+                        <p class="lead">Chromeウェブストアからインストールできます。</p>
+                        <a href="https://chrome.google.com/webstore/detail/kadaiowatter/ogpmacookbmdacllljbakgabghlgajla" class="btn btn-light"><i class="bi bi-chevron-right"></i> 今すぐインストール </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## 変更点

kadaiowatter が遂に Chrome Web Store から利用可能になったので，ウェブサイトのインストール先 URL を修正しました。