### PR TITLE
テスト提出画面での背景のサイズを調整

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,6 +20,7 @@ if (location.href ===        "https://scombz.shibaura-it.ac.jp/lms/course/report
                 background-image: url(${chrome.runtime.getURL("img/kadaiowatta.png")}) !important;
                 background-size: cover;
                 background-blend-mode: unset !important;
+                background-attachment: fixed;
             }
             .course-header {
                 background-color: #FFF7;


### PR DESCRIPTION
`add background-attachment: fixed;`を加えることにより、ページの高さにかかわらず背景にうまく「課題終わった」の画像が表示されるように変更しました。
| 調整前 | 調整後 |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/59430508/235351257-702fa2e5-819e-44c8-9db4-6d2e8c08a364.png)| ![image](https://user-images.githubusercontent.com/59430508/235351242-0b6f4c4f-ec2c-4cf3-b2fd-61519fda047a.png)| 


